### PR TITLE
yaml merge bugfix: remove concurrent modification and iteration

### DIFF
--- a/iac_validate/yaml.py
+++ b/iac_validate/yaml.py
@@ -145,7 +145,7 @@ def merge_dict(
                 merge_dict(value, node, merge_list_items)
         elif isinstance(value, list):
             if key not in destination:
-                destination[key] = value
+                destination[key] = []
             if isinstance(destination[key], list):
                 for i in value:
                     merge_list_item(i, destination[key], merge_list_items)

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -18,6 +18,20 @@ def test_merge_dict():
     result = {"root": {"child1": "abc", "child2": "def"}}
     yaml.merge_dict(source, destination)
     assert destination == result
+    # make sure that the code doesn't hang when merging lists of lists
+    source = {
+        "switch_link_aggregations": [
+            {
+                "switch_ports": [
+                    {"port_id": "7", "serial": "asd"},
+                    {"port_id": "8", "serial": "qwe"},
+                ]
+            }
+        ]
+    }
+    destination = {}
+    yaml.merge_dict(source, destination)
+    assert destination == source
 
 
 def test_merge_list_item():


### PR DESCRIPTION
In yaml.py there is logic that is responsible for merging multiple yaml files in order to create a hierarchy of objects that would be then be validated using yamale. This logic enters an infinite loop for this subdict:
```
switch_link_aggregations:
  - switch_ports:
    - port_id: "7"
      serial: asd
    - port_id: "8"
      serial: qwe
```
This happens because of this piece of code:
```
elif isinstance(value, list):
    if key not in destination:
        destination[key] = value
    if isinstance(destination[key], list):
        for i in value:
            merge_list_item(i, destination[key], merge_list_items)
```
`destination[key]` points to the same data as `value` and then the loop iterates over `value` while adding `i` to `destination[key]` which is the same as `value`. This essentially adds items to `value` while iterating over it at the same time, thus creating an infinite loop that adds to `value` until running out of memory.

I have removed the initial assignment of `destination[key]` to `value` and instead initiated `destination[key]` to an empty list (like in the Golang logic). Then all the list items get merged into the empty list and the result is correct.