### PR TITLE
feat(validator): add duplicate rule ID detection

### DIFF
--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -61,6 +61,13 @@ class Validator:
                             sys.modules["nac_validate.rules"] = mod
                             if spec.loader is not None:
                                 spec.loader.exec_module(mod)
+                                # Check for duplicate rule IDs
+                                if mod.Rule.id in self.rules:
+                                    existing_rule = self.rules[mod.Rule.id]
+                                    raise RuleLoadError(
+                                        filename,
+                                        f"Duplicate rule ID '{mod.Rule.id}' - already defined in rule '{existing_rule.description}'",
+                                    )
                                 self.rules[mod.Rule.id] = mod.Rule
                     except Exception as e:
                         raise RuleLoadError(filename, str(e)) from e

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -46,7 +46,7 @@ class Validator:
         else:
             raise SchemaNotFoundError(f"Schema file not found: {schema_path}")
         self.errors: list[str] = []
-        self.rules = {}
+        self.rules: dict[str, Any] = {}
         if os.path.exists(rules_path):
             logger.info("Loading rules")
             for filename in os.listdir(rules_path):


### PR DESCRIPTION
## Summary

Prevent silent rule overwrites by detecting and reporting duplicate rule IDs during rule loading. Previously, when multiple rule files had the same `Rule.id`, the validator would silently overwrite earlier rules with later ones without any warning. This leads to validation passing when it should fail, causing mutually exclusive or conflicting values being sent to the device (via terraform). This can be very difficult to troubleshoot base don vague/non-existent device error messages. 

## Changes

- Added duplicate rule ID detection in `Validator.__init__` method
- Raises `RuleLoadError` with clear error message when duplicate IDs are found
- Error message includes both the duplicate filename and existing rule description

## Impact

**Before:** Multiple rules with the same ID would silently overwrite each other (last loaded wins)

**After:** Duplicate rule IDs raise an error


## Benefits

- 🛡️ **Prevents silent failures**: Catches configuration errors early
- 🔍 **Clear error messages**: Developers immediately know which rule IDs conflict  
- 📍 **Easy debugging**: Shows both the duplicate file and the original rule
- ✅ **No breaking changes**: Only affects error cases that were previously silent bugs

## Testing

- [x] Manually tested with duplicate rule scenarios
- [x] Verified error messages contain expected information
- [x] Confirmed non-duplicate rules load successfully
- [x] All existing integration tests pass