### PR TITLE
feat: add license-headers check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: local
+    hooks:
+      - id: license-headers
+        name: Check license headers
+        entry: ./scripts/license-headers.sh
+        language: script
+        types: [python]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.12
     hooks:


### PR DESCRIPTION
- Replace find with git ls-files to respect .gitignore
- Accept optional file arguments for pre-commit integration
- Standalone mode checks all tracked Python files

same changes as committed in https://github.com/netascode/nac-test/pull/535